### PR TITLE
Fix for first project run error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To include in your project, update your pom.xml with the following:
         <dependency>
             <groupId>com.github.sgoertzen</groupId>
             <artifactId>sonarbreak</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
         </dependency>
     </dependencies>
 
@@ -23,7 +23,7 @@ To include in your project, update your pom.xml with the following:
             <plugin>
                 <groupId>com.github.sgoertzen</groupId>
                 <artifactId>sonarbreak</artifactId>
-                <version>1.1.2</version>
+                <version>1.1.3</version>
                 <configuration>
                     <sonarServer>https://sonar.yourserver.com</sonarServer>
                 </configuration>
@@ -43,7 +43,7 @@ These parameter goes into the configuration section so the build piece of your p
             <plugin>
                 <groupId>com.github.sgoertzen</groupId>
                 <artifactId>sonarbreak</artifactId>
-                <version>1.1</version>
+                <version>1.1.3</version>
                 <configuration>
                     <sonarServer>https://sonar.yourserver.com</sonarServer>
                     <sonarLookBackSeconds>60</sonarLookBackSeconds>

--- a/src/main/java/com/sgoertzen/sonarbreak/QueryExecutor.java
+++ b/src/main/java/com/sgoertzen/sonarbreak/QueryExecutor.java
@@ -124,7 +124,7 @@ public class QueryExecutor {
         URL queryURL = buildURL(sonarURL, query);
         log.debug("Built a sonar query url of: " + queryURL.toString());
 
-        if (!isURLAvailable(queryURL, SONAR_CONNECTION_RETRIES)) {
+        if (!isURLAvailable(sonarURL, SONAR_CONNECTION_RETRIES)) {
             throw new SonarBreakException(String.format("Unable to get a valid response after %d tries", SONAR_CONNECTION_RETRIES));
         }
 


### PR DESCRIPTION
If a project had never been analyzed before and it was a large project, the plugin could fail while checking if sonar was available.  