### PR TITLE
Added support for sonar branch parameter

### DIFF
--- a/integration-tests/basic-error/pom.xml
+++ b/integration-tests/basic-error/pom.xml
@@ -33,6 +33,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.host.url>http://localhost:9000</sonar.host.url>
-        <sonar.break.maven.plugin.version>1.2.2</sonar.break.maven.plugin.version>
+        <sonar.break.maven.plugin.version>1.2.3</sonar.break.maven.plugin.version>
     </properties>
 </project>

--- a/integration-tests/basic/pom.xml
+++ b/integration-tests/basic/pom.xml
@@ -33,6 +33,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.host.url>http://localhost:9000</sonar.host.url>
-        <sonar.break.maven.plugin.version>1.2.2</sonar.break.maven.plugin.version>
+        <sonar.break.maven.plugin.version>1.2.3</sonar.break.maven.plugin.version>
     </properties>
 </project>

--- a/integration-tests/custom-branch/pom.xml
+++ b/integration-tests/custom-branch/pom.xml
@@ -5,10 +5,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.sgoertzen.test</groupId>
-    <artifactId>sonar-break-test-customkey</artifactId>
+    <artifactId>sonar-break-test-custombranch</artifactId>
     <version>1.0</version>
 
-    <name>sonar-break-test-customkey</name>
+    <name>sonar-break-test-custombranch</name>
 
     <build>
         <plugins>
@@ -33,7 +33,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.host.url>http://localhost:9000</sonar.host.url>
-        <sonar.projectKey>branch123:qa:sonar-break-custom-key</sonar.projectKey>
+        <sonar.branch>custombranch</sonar.branch>
         <sonar.break.maven.plugin.version>1.2.3</sonar.break.maven.plugin.version>
     </properties>
 </project>

--- a/integration-tests/custom-branch/src/main/java/custombranch/CustomBranch.java
+++ b/integration-tests/custom-branch/src/main/java/custombranch/CustomBranch.java
@@ -1,0 +1,7 @@
+package custombranch;
+
+public class CustomBranch {
+    public static void main(String[] args) {
+        System.out.println("In custom branch test");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.sgoertzen</groupId>
     <artifactId>sonar-break-maven-plugin</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/sgoertzen/sonarbreak/SonarBreakMojo.java
+++ b/src/main/java/com/sgoertzen/sonarbreak/SonarBreakMojo.java
@@ -1,6 +1,7 @@
 package com.sgoertzen.sonarbreak;
 
 import com.sgoertzen.sonarbreak.qualitygate.*;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -26,6 +27,8 @@ public class SonarBreakMojo extends AbstractMojo {
     protected String waitForProcessingSeconds;
     @Parameter(property = "sonar.projectKey", defaultValue = "")
     protected String sonarKey;
+    @Parameter(property = "sonar.branch", defaultValue = "")
+    protected String sonarBranch;
 
     protected static String buildErrorString(List<Condition> conditions) {
         StringBuilder builder = new StringBuilder();
@@ -37,13 +40,19 @@ public class SonarBreakMojo extends AbstractMojo {
         return builder.toString();
     }
 
+    @Override
     public void execute() throws MojoExecutionException {
         MavenProject mavenProject = getMavenProject();
         String version = mavenProject.getVersion();
-        if (sonarKey == null || sonarKey.equals("")) {
+        if (StringUtils.isEmpty(sonarKey)) {
 
             sonarKey = String.format("%s:%s", mavenProject.getGroupId(), mavenProject.getArtifactId());
         }
+        if (!StringUtils.isEmpty(sonarBranch)){
+
+            sonarKey = String.format("%s:%s", sonarKey, sonarBranch);
+        }
+
         getLog().info("Querying sonar for analysis on " + sonarKey + ", version: " + version);
 
         try {


### PR DESCRIPTION
Added support for Sonarqube maven plugin's sonar.branch parameter because current (1.2.2) implementation supports only default (no) branch which results in incorrect request for Sonarqube API polling when `-Dsonar.branch` parameter is used. This leads to polling timeout error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sgoertzen/sonar-break-maven-plugin/39)
<!-- Reviewable:end -->
